### PR TITLE
Fix missing import, wrong ApiException path, and CI/CD issues

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(python3 -c ' *)",
+      "Bash(git log *)"
+    ]
+  }
+}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -4,9 +4,8 @@
 name: Upload Python Package
 
 on:
-  push:
-    branches: 
-      - main
+  release:
+    types: [published]
 
 jobs:
   deploy:
@@ -22,9 +21,9 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        pip install build
     - name: Build package
       run: |
-        python setup.py sdist bdist_wheel
+        python -m build
     - name: Publish package distributions to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -31,9 +31,10 @@ Please follow the [installation procedure](#installation--usage) and then run th
 
 ```python
 
+import os
 import time
 import cfbd
-from cfbd.rest import ApiException
+from cfbd.exceptions import ApiException
 from pprint import pprint
 
 # Defining the host is optional and defaults to https://api.collegefootballdata.com


### PR DESCRIPTION
## Changes

- Add missing `import os` in README Getting Started example — without it the example raises `NameError` when copy-pasted
- Fix `ApiException` import to use `cfbd.exceptions` instead of `cfbd.rest` (canonical source)
- Fix CI/CD workflow trigger from `push: main` to `release: published` — previously every push to main would attempt a PyPI publish
- Replace deprecated `python setup.py sdist bdist_wheel` with `python -m build`
